### PR TITLE
Pin genomic-toolkit package version to those of mg RH7

### DIFF
--- a/modules/conda/envs/genomic-toolkit/1.0.yml
+++ b/modules/conda/envs/genomic-toolkit/1.0.yml
@@ -5,19 +5,18 @@ channels:
 dependencies:
   - python=3.8
   - pip
-  - samtools
+  - samtools=1.10
+  - bcftools=1.10
+  - htslib=1.10
   - pysam
   - pysamstats
   - biopython
-  - htslib
-  - bcftools
   - bedtools
-  - bwa
-  - bowtie2
-  - stringtie
-  - subread
-  - picard
-  - sra-tools
-  - fastqc
-  - trimmomatic
-  - hisat2
+  - bwa=0.7
+  - bowtie2=2.4
+  - subread=2.0
+  - picard=2.22
+  - sra-tools=3.0
+  - fastqc=0.11
+  - trimmomatic=0.39
+  - hisat2=2.2

--- a/modules/conda/envs/openslide/3.4.1.lua
+++ b/modules/conda/envs/openslide/3.4.1.lua
@@ -1,0 +1,20 @@
+help([[
+OpenSlide is a C library that provides a simple interface to
+read whole-slide images (also known as virtual slides).
+https://openslide.org/
+]])
+
+-- conda environment name
+local env="openslide"
+
+-- extensions aid in documenting the python version provided
+extensions("python/3.8")
+
+-- always_load must be used because the conda3/init is unloaded (removing
+-- all the conda functions) prior to the execution of conda deactivate
+-- command when the load function is used.
+always_load("miniconda3")
+
+-- use conda to activate environments to ensure proper configuration
+execute {cmd="conda activate " .. env, modeA={"load"}}
+execute {cmd="conda deactivate", modeA={"unload"}}

--- a/modules/conda/envs/openslide/3.4.1.yml
+++ b/modules/conda/envs/openslide/3.4.1.yml
@@ -3,4 +3,5 @@ channels:
   - conda-forge
 dependencies:
   - openslide=3.4.1
+  - openslide-python=1.2.0
   - python=3.8

--- a/modules/conda/envs/openslide/3.4.1.yml
+++ b/modules/conda/envs/openslide/3.4.1.yml
@@ -1,0 +1,6 @@
+name: openslide-3.4.1
+channels:
+  - conda-forge
+dependencies:
+  - openslide=3.4.1
+  - python=3.8

--- a/modules/conda/envs/stringtie/2.2.lua
+++ b/modules/conda/envs/stringtie/2.2.lua
@@ -1,0 +1,20 @@
+help([[
+StringTie is a fast and highly efficient assembler of RNA-Seq alignments into potential transcripts. It uses a novel network flow algorithm as well as an optional de novo assembly step to assemble and quantitate full-length transcripts representing multiple splice variants for each gene locus. Its input can include not only alignments of short reads that can also be used by other transcript assemblers, but also alignments of longer sequences that have been assembled from those reads.
+
+See the website https://ccb.jhu.edu/software/stringtie/ for more information.
+]])
+
+-- conda environment name
+local env="stringtie-2.2"
+
+-- extensions aid in documenting the python version provided
+extensions("python/3.8")
+
+-- always_load must be used because the conda3/init is unloaded (removing
+-- all the conda functions) prior to the execution of conda deactivate
+-- command when the load function is used.
+always_load("miniconda3")
+
+-- use conda to activate environments to ensure proper configuration
+execute {cmd="conda activate " .. env, modeA={"load"}}
+execute {cmd="conda deactivate", modeA={"unload"}}

--- a/modules/conda/envs/stringtie/2.2.yml
+++ b/modules/conda/envs/stringtie/2.2.yml
@@ -1,0 +1,8 @@
+name: stringtie-2.2
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.8
+  - pip
+  - stringtie=2.2


### PR DESCRIPTION
Also removes stringtie from the genomic-toolkit and adds it as a standalone environment.